### PR TITLE
support for service authority

### DIFF
--- a/libs/providers/flagd/README.md
+++ b/libs/providers/flagd/README.md
@@ -38,6 +38,7 @@ Options can be defined in the constructor or as environment variables. Construct
 | selector                               | FLAGD_SOURCE_SELECTOR          | string  | -                                                              |                  |
 | cache                                  | FLAGD_CACHE                    | string  | lru                                                            | lru, disabled    |
 | maxCacheSize                           | FLAGD_MAX_CACHE_SIZE           | int     | 1000                                                           |                  |
+| serviceAuthority                       | FLAGD_SERVICE_AUTHORITY        | string  | -                                                              | rpc, in-process  |
 
 #### Resolver type-specific Defaults
 

--- a/libs/providers/flagd/src/lib/configuration.spec.ts
+++ b/libs/providers/flagd/src/lib/configuration.spec.ts
@@ -31,7 +31,7 @@ describe('Configuration', () => {
     const resolverType = 'in-process';
     const selector = 'app=weather';
     const offlineFlagSourcePath = '/tmp/flags.json';
-    const servAuthority = 'test-service';
+    const serviceAuthority = 'test-service2';
 
     process.env['FLAGD_HOST'] = host;
     process.env['FLAGD_PORT'] = `${port}`;
@@ -42,7 +42,7 @@ describe('Configuration', () => {
     process.env['FLAGD_SOURCE_SELECTOR'] = `${selector}`;
     process.env['FLAGD_RESOLVER'] = `${resolverType}`;
     process.env['FLAGD_OFFLINE_FLAG_SOURCE_PATH'] = offlineFlagSourcePath;
-    process.env['FLAGD_SERVICE_AUTHORITY'] = servAuthority;
+    process.env['FLAGD_SERVICE_AUTHORITY'] = serviceAuthority;
 
     expect(getConfig()).toStrictEqual({
       host,
@@ -54,7 +54,7 @@ describe('Configuration', () => {
       resolverType,
       selector,
       offlineFlagSourcePath,
-      servAuthority,
+      serviceAuthority,
     });
   });
 

--- a/libs/providers/flagd/src/lib/configuration.spec.ts
+++ b/libs/providers/flagd/src/lib/configuration.spec.ts
@@ -31,6 +31,7 @@ describe('Configuration', () => {
     const resolverType = 'in-process';
     const selector = 'app=weather';
     const offlineFlagSourcePath = '/tmp/flags.json';
+    const servAuthority = 'test-service';
 
     process.env['FLAGD_HOST'] = host;
     process.env['FLAGD_PORT'] = `${port}`;
@@ -41,6 +42,7 @@ describe('Configuration', () => {
     process.env['FLAGD_SOURCE_SELECTOR'] = `${selector}`;
     process.env['FLAGD_RESOLVER'] = `${resolverType}`;
     process.env['FLAGD_OFFLINE_FLAG_SOURCE_PATH'] = offlineFlagSourcePath;
+    process.env['FLAGD_SERVICE_AUTHORITY'] = servAuthority;
 
     expect(getConfig()).toStrictEqual({
       host,
@@ -52,6 +54,7 @@ describe('Configuration', () => {
       resolverType,
       selector,
       offlineFlagSourcePath,
+      servAuthority,
     });
   });
 
@@ -64,6 +67,7 @@ describe('Configuration', () => {
       cache: 'lru',
       resolverType: 'rpc',
       selector: '',
+      serviceAuthority: '',
     };
 
     process.env['FLAGD_HOST'] = 'override';

--- a/libs/providers/flagd/src/lib/configuration.ts
+++ b/libs/providers/flagd/src/lib/configuration.ts
@@ -74,7 +74,7 @@ export interface Config {
    *
    * @default ''
    */
-  serviceAuthority: string;
+  serviceAuthority?: string;
 }
 
 export type FlagdProviderOptions = Partial<Config>;

--- a/libs/providers/flagd/src/lib/configuration.ts
+++ b/libs/providers/flagd/src/lib/configuration.ts
@@ -68,6 +68,13 @@ export interface Config {
    * @default 1000
    */
   maxCacheSize?: number;
+
+  /**
+   * The target host (authority) when routing requests through a proxy (e.g. Envoy)
+   *
+   * @default ''
+   */
+  serviceAuthority: string;
 }
 
 export type FlagdProviderOptions = Partial<Config>;
@@ -94,6 +101,7 @@ enum ENV_VAR {
   FLAGD_SOURCE_SELECTOR = 'FLAGD_SOURCE_SELECTOR',
   FLAGD_RESOLVER = 'FLAGD_RESOLVER',
   FLAGD_OFFLINE_FLAG_SOURCE_PATH = 'FLAGD_OFFLINE_FLAG_SOURCE_PATH',
+  FLAGD_SERVICE_AUTHORITY = 'FLAGD_SERVICE_AUTHORITY',
 }
 
 const getEnvVarConfig = (): Partial<Config> => ({
@@ -123,6 +131,9 @@ const getEnvVarConfig = (): Partial<Config> => ({
   }),
   ...(process.env[ENV_VAR.FLAGD_OFFLINE_FLAG_SOURCE_PATH] && {
     offlineFlagSourcePath: process.env[ENV_VAR.FLAGD_OFFLINE_FLAG_SOURCE_PATH],
+  }),
+  ...(process.env[ENV_VAR.FLAGD_SERVICE_AUTHORITY] && {
+    serviceAuthority: process.env[ENV_VAR.FLAGD_SERVICE_AUTHORITY],
   }),
 });
 


### PR DESCRIPTION
Adding a new config option that allows flagd clients to override the authority. This is useful when running gRPC sync service behind proxy e.g. envoy, istio etc. For more details, please refer this https://github.com/open-feature/java-sdk-contrib/pull/949

adds this new feature
Related Issues
https://github.com/open-feature/java-sdk-contrib/pull/949